### PR TITLE
Change a way of handling a settings

### DIFF
--- a/saleor_app_framework/app_framework/core/conf.py
+++ b/saleor_app_framework/app_framework/core/conf.py
@@ -9,7 +9,7 @@ from pydantic import BaseSettings, DirectoryPath, FilePath
 SETTINGS_ENV_VARIABLE = "APP_SETTINGS"
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 PROJECT_DIR = os.path.dirname(__file__)
 
 

--- a/saleor_app_framework/app_framework/core/conf.py
+++ b/saleor_app_framework/app_framework/core/conf.py
@@ -1,27 +1,59 @@
 import importlib
+import logging
 import os
+from functools import lru_cache
+from typing import Optional
 
-SETTINGS_ENV_VARIABLE = "APP_SETTINGS_MODULE"
+from pydantic import BaseSettings
 
-
-class ImproperlyConfigured(Exception):
-    pass
-
-
-class Settings(object):
-    def __init__(self, settings_module):
-        # store the settings module in case someone later cares
-        self.SETTINGS_MODULE = settings_module
-
-        mod = importlib.import_module(self.SETTINGS_MODULE)
-
-        self._explicit_settings = set()
-        for setting in dir(mod):
-            if setting.isupper():
-                setting_value = getattr(mod, setting)
-
-                setattr(self, setting, setting_value)
-                self._explicit_settings.add(setting)
+SETTINGS_ENV_VARIABLE = "APP_SETTINGS"
 
 
-settings = Settings(os.environ.get(SETTINGS_ENV_VARIABLE))
+logger = logging.getLogger(__file__)
+PROJECT_DIR = os.path.dirname(__file__)
+
+
+class Settings(BaseSettings):
+    app_name: str = "App"
+    project_dir: str = PROJECT_DIR
+    static_dir: str = os.path.join(PROJECT_DIR, "static")
+    templates_dir: str = os.path.join(PROJECT_DIR, "templates")
+    manigest_path: str = os.path.join(PROJECT_DIR, "manifest.json")
+    debug: bool = True
+    dev_saleor_domain: Optional[str] = None
+    dev_saleor_token: Optional[str] = None
+
+
+def import_string(dotted_path):
+    """
+    Import a dotted module path and return the attribute/class designated by the
+    last name in the path. Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit(".", 1)
+    except ValueError as err:
+        raise ImportError("%s doesn't look like a module path" % dotted_path) from err
+
+    module = importlib.import_module(module_path)
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError as err:
+        raise ImportError(
+            'Module "%s" does not define a "%s" attribute/class'
+            % (module_path, class_name)
+        ) from err
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    settings_path = os.environ.get(SETTINGS_ENV_VARIABLE)
+    if not settings_path:
+        logger.warning(
+            f"{SETTINGS_ENV_VARIABLE} was not provided. Using default settings."
+        )
+        return Settings()
+    settings = import_string(settings_path)()
+    if not isinstance(settings, Settings):
+        logger.warning("Incorrect type of settings object")
+    return settings

--- a/saleor_app_framework/app_framework/core/conf.py
+++ b/saleor_app_framework/app_framework/core/conf.py
@@ -4,7 +4,7 @@ import os
 from functools import lru_cache
 from typing import Optional
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, DirectoryPath, FilePath
 
 SETTINGS_ENV_VARIABLE = "APP_SETTINGS"
 
@@ -15,10 +15,10 @@ PROJECT_DIR = os.path.dirname(__file__)
 
 class Settings(BaseSettings):
     app_name: str = "App"
-    project_dir: str
-    static_dir: str
-    templates_dir: str
-    manifest_path: str
+    project_dir: DirectoryPath
+    static_dir: DirectoryPath
+    templates_dir: DirectoryPath
+    manifest_path: FilePath
     debug: bool = True
     dev_saleor_domain: Optional[str] = None
     dev_saleor_token: Optional[str] = None
@@ -53,7 +53,7 @@ def get_settings() -> Settings:
             f"Env {SETTINGS_ENV_VARIABLE} was not provided. Provide python path to "
             f"project's settings class."
         )
-    settings = import_string(settings_path)()
+    settings = import_string(settings_path)
     if not isinstance(settings, Settings):
         logger.warning("Incorrect type of settings object.")
     return settings

--- a/saleor_app_framework/app_framework/core/conf.py
+++ b/saleor_app_framework/app_framework/core/conf.py
@@ -15,10 +15,10 @@ PROJECT_DIR = os.path.dirname(__file__)
 
 class Settings(BaseSettings):
     app_name: str = "App"
-    project_dir: str = PROJECT_DIR
-    static_dir: str = os.path.join(PROJECT_DIR, "static")
-    templates_dir: str = os.path.join(PROJECT_DIR, "templates")
-    manigest_path: str = os.path.join(PROJECT_DIR, "manifest.json")
+    project_dir: str
+    static_dir: str
+    templates_dir: str
+    manifest_path: str
     debug: bool = True
     dev_saleor_domain: Optional[str] = None
     dev_saleor_token: Optional[str] = None
@@ -49,11 +49,11 @@ def import_string(dotted_path):
 def get_settings() -> Settings:
     settings_path = os.environ.get(SETTINGS_ENV_VARIABLE)
     if not settings_path:
-        logger.warning(
-            f"{SETTINGS_ENV_VARIABLE} was not provided. Using default settings."
+        raise Exception(
+            f"Env {SETTINGS_ENV_VARIABLE} was not provided. Provide python path to "
+            f"project's settings class."
         )
-        return Settings()
     settings = import_string(settings_path)()
     if not isinstance(settings, Settings):
-        logger.warning("Incorrect type of settings object")
+        logger.warning("Incorrect type of settings object.")
     return settings

--- a/saleor_app_framework/app_framework/core/graphql.py
+++ b/saleor_app_framework/app_framework/core/graphql.py
@@ -3,8 +3,8 @@ import logging
 
 from aiohttp import ClientError, ClientSession
 
-from .conf import settings
 from .errors import GraphQLError
+from .conf import get_settings
 
 DEFAULT_REQUEST_TIMEOUT = 10
 
@@ -13,8 +13,9 @@ logger = logging.getLogger("graphql")
 
 def get_saleor_api_url(domain: str) -> str:
     protocol = "https"
-    if settings.DEBUG:
-        logger.warning("Using non secured protocol.")
+    settings = get_settings()
+    if settings.debug:
+        logger.warning("Using non secured protocol")
         protocol = "http"
     url = f"{protocol}://{domain}"
     return f"{url}/graphql/"

--- a/saleor_app_framework/app_framework/core/install.py
+++ b/saleor_app_framework/app_framework/core/install.py
@@ -9,7 +9,7 @@ from .graphql import GraphQLError, get_executor, get_saleor_api_url
 from .mutations import CREATE_WEBHOOK
 from .types import AppToken, DomainName, Url, WebhookData
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 async def install_app(

--- a/saleor_app_framework/app_framework/core/install.py
+++ b/saleor_app_framework/app_framework/core/install.py
@@ -3,7 +3,7 @@ import secrets
 import string
 from typing import Awaitable, Callable, List
 
-from ..core.conf import settings
+from ..core.conf import get_settings
 from .errors import InstallAppError
 from .graphql import GraphQLError, get_executor, get_saleor_api_url
 from .mutations import CREATE_WEBHOOK
@@ -25,13 +25,15 @@ async def install_app(
     api_url = get_saleor_api_url(domain)
     executor = get_executor(host=api_url, auth_token=token)
 
+    settings = get_settings()
+
     response, errors = await executor(
         CREATE_WEBHOOK,
         variables={
             "input": {
                 "targetUrl": target_url,
                 "events": [event.upper() for event in events],
-                "name": settings.APP_NAME,
+                "name": settings.app_name,
                 "secretKey": secret_key,
             }
         },

--- a/saleor_app_framework/app_framework/core/manifest.py
+++ b/saleor_app_framework/app_framework/core/manifest.py
@@ -11,8 +11,8 @@ def get_app_manifest():
     settings = get_settings()
     if MANIFEST is not None:
         return MANIFEST
-    if not os.path.exists(settings.manigest_path):
+    if not os.path.exists(settings.manifest_path):
         return None
-    with open(settings.manigest_path, mode="r") as f:
+    with open(settings.manifest_path, mode="r") as f:
         MANIFEST = json.load(f)
     return MANIFEST

--- a/saleor_app_framework/app_framework/core/manifest.py
+++ b/saleor_app_framework/app_framework/core/manifest.py
@@ -1,17 +1,18 @@
 import json
 import os
 
-from .conf import settings
+from .conf import get_settings
 
 MANIFEST = None
 
 
 def get_app_manifest():
     global MANIFEST
+    settings = get_settings()
     if MANIFEST is not None:
         return MANIFEST
-    if not os.path.exists(settings.MANIFEST_PATH):
+    if not os.path.exists(settings.manigest_path):
         return None
-    with open(settings.MANIFEST_PATH, mode="r") as f:
+    with open(settings.manigest_path, mode="r") as f:
         MANIFEST = json.load(f)
     return MANIFEST

--- a/saleor_app_framework/app_framework/core/manifest.py
+++ b/saleor_app_framework/app_framework/core/manifest.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 from .conf import get_settings
 
@@ -11,8 +10,6 @@ def get_app_manifest():
     settings = get_settings()
     if MANIFEST is not None:
         return MANIFEST
-    if not os.path.exists(settings.manifest_path):
-        return None
     with open(settings.manifest_path, mode="r") as f:
         MANIFEST = json.load(f)
     return MANIFEST

--- a/saleor_app_framework/app_framework/core/tests/test_conf.py
+++ b/saleor_app_framework/app_framework/core/tests/test_conf.py
@@ -5,16 +5,15 @@ import pytest
 
 from ..conf import SETTINGS_ENV_VARIABLE, Settings, get_settings
 
+settings = Settings.construct(
+    app_name="TMP app",
+    project_dir=".",
+    manifest_path="/path",
+    static_dir="static",
+    templates_dir="templates",
+)
 
-class TmpSettings(Settings):
-    app_name = "TMP app"
-    manifest_path = ""
-    static_dir = ""
-    templates_dir = ""
-    project_dir = ""
-
-
-APP_SETTINGS = "saleor_app_framework.app_framework.core.tests.test_conf.TmpSettings"
+APP_SETTINGS = "saleor_app_framework.app_framework.core.tests.test_conf.settings"
 
 
 @pytest.fixture(autouse=True)
@@ -36,5 +35,5 @@ def test_get_settings_raises_error_when_incorrect_path():
 def test_get_settings():
     with patch.dict(os.environ, {SETTINGS_ENV_VARIABLE: APP_SETTINGS}):
         settings = get_settings()
-    assert isinstance(settings, TmpSettings)
+    assert isinstance(settings, Settings)
     assert settings.app_name == "TMP app"

--- a/saleor_app_framework/app_framework/core/tests/test_conf.py
+++ b/saleor_app_framework/app_framework/core/tests/test_conf.py
@@ -23,10 +23,7 @@ def clear_settings_cache():
 
 
 def test_get_settings_returns_settings_object():
-    with patch.dict(
-        os.environ,
-        {SETTINGS_ENV_VARIABLE: APP_SETTINGS},
-    ):
+    with patch.dict(os.environ, {SETTINGS_ENV_VARIABLE: APP_SETTINGS}):
         assert isinstance(get_settings(), Settings)
 
 
@@ -37,10 +34,7 @@ def test_get_settings_raises_error_when_incorrect_path():
 
 
 def test_get_settings():
-    with patch.dict(
-        os.environ,
-        {SETTINGS_ENV_VARIABLE: APP_SETTINGS},
-    ):
+    with patch.dict(os.environ, {SETTINGS_ENV_VARIABLE: APP_SETTINGS}):
         settings = get_settings()
     assert isinstance(settings, TmpSettings)
     assert settings.app_name == "TMP app"

--- a/saleor_app_framework/app_framework/core/tests/test_conf.py
+++ b/saleor_app_framework/app_framework/core/tests/test_conf.py
@@ -1,0 +1,46 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ..conf import SETTINGS_ENV_VARIABLE, Settings, get_settings
+
+
+class TmpSettings(Settings):
+    app_name = "TMP app"
+    manifest_path = ""
+    static_dir = ""
+    templates_dir = ""
+    project_dir = ""
+
+
+APP_SETTINGS = "saleor_app_framework.app_framework.core.tests.test_conf.TmpSettings"
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+
+
+def test_get_settings_returns_settings_object():
+    with patch.dict(
+        os.environ,
+        {SETTINGS_ENV_VARIABLE: APP_SETTINGS},
+    ):
+        assert isinstance(get_settings(), Settings)
+
+
+def test_get_settings_raises_error_when_incorrect_path():
+    with pytest.raises(ImportError):
+        with patch.dict(os.environ, {SETTINGS_ENV_VARIABLE: "wrong.python.path"}):
+            get_settings()
+
+
+def test_get_settings():
+    with patch.dict(
+        os.environ,
+        {SETTINGS_ENV_VARIABLE: APP_SETTINGS},
+    ):
+        settings = get_settings()
+    assert isinstance(settings, TmpSettings)
+    assert settings.app_name == "TMP app"

--- a/saleor_app_framework/app_framework/endpoints/configuration.py
+++ b/saleor_app_framework/app_framework/endpoints/configuration.py
@@ -6,7 +6,7 @@ from fastapi.requests import Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from ..core.conf import settings
+from ..core.conf import Settings, get_settings
 from ..core.errors import InstallAppError
 from ..core.graphql import GraphQLError
 from ..core.install import install_app
@@ -45,6 +45,7 @@ def initialize_configuration_router(
         request: Request,
         saleor_domain=Depends(saleor_domain_header),
         token=Depends(saleor_token),
+        settings: Settings = Depends(get_settings),
     ):
         context = {
             "request": request,
@@ -52,7 +53,7 @@ def initialize_configuration_router(
             "domain": saleor_domain,
             "token": token,
         }
-        return Jinja2Templates(directory=settings.STATIC_DIR).TemplateResponse(
+        return Jinja2Templates(directory=settings.static_dir).TemplateResponse(
             configuration_template, context
         )
 

--- a/saleor_app_framework/app_framework/endpoints/deps.py
+++ b/saleor_app_framework/app_framework/endpoints/deps.py
@@ -5,7 +5,7 @@ from typing import Awaitable, Callable
 
 from fastapi import Depends, Header, HTTPException, Request
 
-from ..core.conf import settings
+from ..core.conf import Settings, get_settings
 from ..core.types import DomainName, WebhookData
 from ..core.validators import verify_token
 from ..schemas.webhooks.handlers import WebhookHandlers
@@ -19,10 +19,11 @@ SALEOR_SIGNATURE_HEADER = "x-saleor-signature"
 
 
 async def saleor_domain_header(
-    saleor_domain=Header(None, alias=SALEOR_DOMAIN_HEADER)
+    saleor_domain=Header(None, alias=SALEOR_DOMAIN_HEADER),
+    settings: Settings = Depends(get_settings),
 ) -> DomainName:
-    if settings.DEBUG:
-        saleor_domain = saleor_domain or settings.DEV_SALEOR_DOMAIN
+    if settings.debug:
+        saleor_domain = saleor_domain or settings.dev_saleor_domain
     if not saleor_domain:
         logger.warning(f"Missing {SALEOR_DOMAIN_HEADER.upper()} header.")
         raise HTTPException(
@@ -31,9 +32,12 @@ async def saleor_domain_header(
     return saleor_domain
 
 
-async def saleor_token(token=Header(None, alias=SALEOR_TOKEN_HEADER)) -> str:
-    if settings.DEBUG:
-        token = token or settings.DEV_SALEOR_TOKEN
+async def saleor_token(
+    token=Header(None, alias=SALEOR_TOKEN_HEADER),
+    settings: Settings = Depends(get_settings),
+) -> str:
+    if settings.debug:
+        token = token or settings.dev_saleor_token
     if not token:
         logger.warning(f"Missing {SALEOR_TOKEN_HEADER.upper()} header.")
         raise HTTPException(

--- a/saleor_app_framework/app_framework/endpoints/deps.py
+++ b/saleor_app_framework/app_framework/endpoints/deps.py
@@ -10,7 +10,7 @@ from ..core.types import DomainName, WebhookData
 from ..core.validators import verify_token
 from ..schemas.webhooks.handlers import WebhookHandlers
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 SALEOR_DOMAIN_HEADER = "x-saleor-domain"
 SALEOR_TOKEN_HEADER = "x-saleor-token"


### PR DESCRIPTION
- Drop simple settings object build based on Django solution
- Add pydantic Settings object to handle all app settings. 
More details can be found here: https://fastapi.tiangolo.com/advanced/settings/#settings-and-environment-variables

Tldr:
```
class AppSettings(Settings):
    project_dir = PROJECT_DIR
    static_dir = os.path.join(PROJECT_DIR, "static")
    templates_dir = os.path.join(PROJECT_DIR, "templates")
```
or
```
class AppSettings(Settings):
    class Config:
        env_file = ".env"
```