### PR TITLE
Prevent redundant app installations

### DIFF
--- a/samples/complex_app/db.py
+++ b/samples/complex_app/db.py
@@ -9,7 +9,7 @@ configuration = sqlalchemy.Table(
     "configuration",
     metadata,
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-    sqlalchemy.Column("domain_name", sqlalchemy.String),
+    sqlalchemy.Column("domain_name", sqlalchemy.String, unique=True),
     sqlalchemy.Column("webhook_id", sqlalchemy.String),
     sqlalchemy.Column("webhook_token", sqlalchemy.String),
     sqlalchemy.Column("webhook_secret", sqlalchemy.String),

--- a/samples/simple_app/app.py
+++ b/samples/simple_app/app.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Dict, Optional
 
 import uvicorn
 from fastapi.param_functions import Depends
@@ -16,6 +17,7 @@ from saleor_app.schemas.core import DomainName, WebhookData
 from saleor_app.schemas.handlers import Payload, WebhookHandlers
 
 PROJECT_DIR = Path(__file__).parent
+WEBHOOK_STORAGE: Dict[DomainName, WebhookData] = dict()
 
 settings = Settings(
     app_name="SimpleApp",
@@ -49,17 +51,14 @@ async def validate_domain(domain_name: DomainName) -> bool:
 
 
 async def store_app_data(domain_name: DomainName, app_data: WebhookData):
+    WEBHOOK_STORAGE[domain_name] = app_data
     print("Called store_app_data")
     print(domain_name)
     print(app_data)
 
 
-async def get_webhook_details(domain_name: DomainName) -> WebhookData:
-    return WebhookData(
-        token="auth-token",
-        webhook_id="webhook-id",
-        webhook_secret_key="webhook-secret-key",
-    )
+async def get_webhook_details(domain_name: DomainName) -> Optional[WebhookData]:
+    return WEBHOOK_STORAGE.get(domain_name, None)
 
 
 async def product_created(payload: Payload, saleor_domain: DomainName):

--- a/src/saleor_app/app.py
+++ b/src/saleor_app/app.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Optional
 
 from fastapi import APIRouter, FastAPI
 
@@ -15,7 +15,7 @@ class SaleorApp(FastAPI):
         validate_domain: Callable[[DomainName], Awaitable[bool]],
         save_app_data: Callable[[DomainName, WebhookData], Awaitable],
         webhook_handlers: WebhookHandlers,
-        get_webhook_details: Callable[[DomainName], Awaitable[WebhookData]],
+        get_webhook_details: Callable[[DomainName], Awaitable[Optional[WebhookData]]],
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/src/saleor_app/endpoints.py
+++ b/src/saleor_app/endpoints.py
@@ -44,10 +44,12 @@ async def install(
             request.app.extra["saleor"]["webhook_handlers"].get_assigned_events(),
             target_url,
             request.app.extra["saleor"]["save_app_data"],
+            request.app.extra["saleor"]["get_webhook_details"],
         )
     except (InstallAppError, GraphQLError):
         raise HTTPException(
-            status_code=403, detail="Incorrect token or not enough permissions"
+            status_code=403,
+            detail="Incorrect token, not enough permissions or app already installed",
         )
 
     return {}

--- a/src/saleor_app/install.py
+++ b/src/saleor_app/install.py
@@ -18,7 +18,12 @@ async def install_app(
     events: List[str],
     target_url: Url,
     save_app_data: Callable[[DomainName, WebhookData], Awaitable],
+    get_webhook_details: Callable[[DomainName], Awaitable[WebhookData]],
 ):
+    webhook_details = await get_webhook_details(domain)
+    if webhook_details:
+        raise InstallAppError("App is already installed for %s.", domain)
+
     alphabet = string.ascii_letters + string.digits
     secret_key = "".join(secrets.choice(alphabet) for _ in range(20))
 

--- a/src/saleor_app/tests/sample_app.py
+++ b/src/saleor_app/tests/sample_app.py
@@ -28,6 +28,8 @@ async def store_app_data(domain_name: DomainName, app_data: WebhookData):
 
 
 async def get_webhook_details(domain_name: DomainName):
+    if domain_name != "example.com":
+        return None
     return WebhookData(
         token="auth-token",
         webhook_id="webhook-id",

--- a/src/saleor_app/tests/test_endpoints.py
+++ b/src/saleor_app/tests/test_endpoints.py
@@ -63,6 +63,19 @@ async def test_install(app, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_install_failed_when_app_already_installed(app):
+    app.dependency_overrides[verify_saleor_domain] = lambda: True
+    base_url, saleor_domain = "http://test", "example.com"
+    async with AsyncClient(app=app, base_url=base_url) as ac:
+        response = await ac.post(
+            "configuration/install",
+            json={"auth_token": "saleor-app-token"},
+            headers={SALEOR_DOMAIN_HEADER: saleor_domain},
+        )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_install_failed_installation(app, monkeypatch):
     app.dependency_overrides[verify_saleor_domain] = lambda: True
     app.dependency_overrides[saleor_domain_header] = lambda: "not-installed-example.com"

--- a/src/saleor_app/tests/test_endpoints.py
+++ b/src/saleor_app/tests/test_endpoints.py
@@ -14,7 +14,7 @@ from saleor_app.deps import (
     webhook_event_type,
 )
 from saleor_app.schemas.handlers import WebhookHandlers
-from saleor_app.tests.sample_app import store_app_data
+from saleor_app.tests.sample_app import get_webhook_details, store_app_data
 
 
 @pytest.mark.asyncio
@@ -56,6 +56,7 @@ async def test_install(app, monkeypatch):
         ["product_created", "product_updated", "product_deleted"],
         "http://test/webhook/",
         store_app_data,
+        get_webhook_details,
     )
 
     assert validate_domain_mock.called
@@ -64,7 +65,7 @@ async def test_install(app, monkeypatch):
 @pytest.mark.asyncio
 async def test_install_failed_installation(app, monkeypatch):
     app.dependency_overrides[verify_saleor_domain] = lambda: True
-    app.dependency_overrides[saleor_domain_header] = lambda: "example.com"
+    app.dependency_overrides[saleor_domain_header] = lambda: "not-installed-example.com"
 
     json_failed_response = {
         "data": {

--- a/src/saleor_app/tests/test_install.py
+++ b/src/saleor_app/tests/test_install.py
@@ -67,6 +67,37 @@ async def test_install_app(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_install_app_failed_when_already_installed():
+    get_webhook_details_mock = AsyncMock(
+        WebhookData(
+            token="auth-token",
+            webhook_id="webhook-id",
+            webhook_secret_key="webhook-secret-key",
+        )
+    )
+    mocked_executor = AsyncMock()
+    save_app_data_fun = AsyncMock()
+
+    events = ["ORDER_CREATED", "PRODUCT_CREATED"]
+    target_url = "saleor.io/app/webhook-url"
+    saleor_store_domain = "saleor.io"
+    saleor_app_token = "saleor-token"
+
+    with pytest.raises(InstallAppError):
+        await install_app(
+            domain=saleor_store_domain,
+            token=saleor_app_token,
+            events=events,
+            target_url=target_url,
+            save_app_data=save_app_data_fun,
+            get_webhook_details=get_webhook_details_mock,
+        )
+    get_webhook_details_mock.assert_awaited_once_with(saleor_store_domain)
+    assert not mocked_executor.called
+    assert not save_app_data_fun.called
+
+
+@pytest.mark.asyncio
 async def test_install_app_graphql_error(monkeypatch):
     json_failed_response = {
         "errors": [

--- a/src/saleor_app/tests/test_install.py
+++ b/src/saleor_app/tests/test_install.py
@@ -29,6 +29,7 @@ async def test_install_app(monkeypatch):
     monkeypatch.setattr("saleor_app.install.secrets.choice", lambda _: "a")
 
     save_app_data_fun = AsyncMock()
+    get_webhook_details_mock = AsyncMock(return_value=None)
 
     events = ["ORDER_CREATED", "PRODUCT_CREATED"]
     target_url = "saleor.io/app/webhook-url"
@@ -41,6 +42,7 @@ async def test_install_app(monkeypatch):
         events=events,
         target_url=target_url,
         save_app_data=save_app_data_fun,
+        get_webhook_details=get_webhook_details_mock,
     )
 
     expected_secret_key = "a" * 20
@@ -52,8 +54,8 @@ async def test_install_app(monkeypatch):
             "secretKey": expected_secret_key,
         }
     }
+    get_webhook_details_mock.assert_awaited_once_with(saleor_store_domain)
     mocked_executor.assert_awaited_once_with(CREATE_WEBHOOK, variables=variables)
-
     save_app_data_fun.assert_awaited_once_with(
         saleor_store_domain,
         WebhookData(
@@ -91,6 +93,7 @@ async def test_install_app_graphql_error(monkeypatch):
     monkeypatch.setattr("saleor_app.install.secrets.choice", lambda _: "a")
 
     save_app_data_fun = AsyncMock()
+    get_webhook_details_mock = AsyncMock(return_value=None)
 
     events = ["ORDER_CREATED", "PRODUCT_CREATED"]
     target_url = "saleor.io/app/webhook-url"
@@ -104,6 +107,7 @@ async def test_install_app_graphql_error(monkeypatch):
             events=events,
             target_url=target_url,
             save_app_data=save_app_data_fun,
+            get_webhook_details=get_webhook_details_mock,
         )
 
     expected_secret_key = "a" * 20
@@ -115,6 +119,7 @@ async def test_install_app_graphql_error(monkeypatch):
             "secretKey": expected_secret_key,
         }
     }
+    get_webhook_details_mock.assert_awaited_once_with(saleor_store_domain)
     mocked_executor.assert_awaited_once_with(CREATE_WEBHOOK, variables=variables)
 
     assert not save_app_data_fun.called
@@ -150,6 +155,7 @@ async def test_install_app_mutation_error(monkeypatch):
     monkeypatch.setattr("saleor_app.install.secrets.choice", lambda _: "a")
 
     save_app_data_fun = AsyncMock()
+    get_webhook_details_mock = AsyncMock(return_value=None)
 
     events = ["ORDER_CREATED", "PRODUCT_CREATED"]
     target_url = "saleor.io/app/webhook-url"
@@ -163,6 +169,7 @@ async def test_install_app_mutation_error(monkeypatch):
             events=events,
             target_url=target_url,
             save_app_data=save_app_data_fun,
+            get_webhook_details=get_webhook_details_mock,
         )
 
     expected_secret_key = "a" * 20
@@ -174,6 +181,7 @@ async def test_install_app_mutation_error(monkeypatch):
             "secretKey": expected_secret_key,
         }
     }
+    get_webhook_details_mock.assert_awaited_once_with(saleor_store_domain)
     mocked_executor.assert_awaited_once_with(CREATE_WEBHOOK, variables=variables)
 
     assert not save_app_data_fun.called


### PR DESCRIPTION
* Prevent redundant app installations by checking if the app was already installed for a provided domain.
* Add simple implementation of `get_webhook_details` to sample apps.